### PR TITLE
Fix profile and legend flex

### DIFF
--- a/client/app/(driver)/profile.tsx
+++ b/client/app/(driver)/profile.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-require-imports */
-import { Pressable, View, Text, Image } from "react-native";
+import { Pressable, View, Text, Image, Dimensions } from "react-native";
 import { styles } from "../../assets/styles";
 
 interface ProfileProps {
@@ -28,14 +28,21 @@ export default function Profile({
         </Pressable>
 
         <View style={styles.rowContainer}>
-          <View style={styles.imageWrapper}>
+          <View
+            style={{
+              padding: 10,
+              borderRadius: 100,
+              borderWidth: 3,
+              justifyContent: "center",
+              alignItems: "center",
+            }}
+          >
             <Image
-              source={require("@/assets/images/Ellipse 215.png")}
-              style={styles.ellipseImage}
-            />
-            <Image
+              style={{
+                width: Dimensions.get("window").width * 0.07,
+                height: Dimensions.get("window").width * 0.07,
+              }}
               source={require("@/assets/images/user.png")}
-              style={styles.userImage}
             />
           </View>
           <Text style={styles.title}>Driver NetID: {netid}</Text>

--- a/client/assets/styles.tsx
+++ b/client/assets/styles.tsx
@@ -778,9 +778,8 @@ export const styles = StyleSheet.create({
     marginBottom: 7,
   },
   legendText: {
-    left: 5,
     fontSize: 12,
-    marginLeft: 5,
+    marginLeft: 10,
   },
 
   // driver profile
@@ -809,22 +808,6 @@ export const styles = StyleSheet.create({
     borderRadius: 10,
     paddingTop: "13%",
     zIndex: 100,
-  },
-  imageWrapper: {
-    width: Dimensions.get("window").width * 0.2,
-    height: Dimensions.get("window").height * 0.07,
-    position: "relative",
-    justifyContent: "center",
-    alignItems: "center",
-  },
-  ellipseImage: {
-    width: "150%",
-    resizeMode: "contain",
-  },
-  userImage: {
-    width: "50%",
-    borderRadius: 20,
-    position: "absolute",
   },
   rowContainer: {
     flexDirection: "row",

--- a/client/components/Student_Legend.tsx
+++ b/client/components/Student_Legend.tsx
@@ -5,27 +5,21 @@ import { FontAwesome6 } from "@expo/vector-icons";
 import { styles } from "@/assets/styles";
 
 export default function Legend() {
-  const [width, setWidth] = React.useState(40);
-
+  const [open, setOpen] = React.useState(false);
   return (
     <View
       style={{
         backgroundColor: "white",
         borderRadius: 10,
         shadowOpacity: 0.5,
-        width: width,
         padding: 10,
       }}
     >
-      <View
-        style={{ flexDirection: "row", alignItems: "center", marginBottom: 7 }}
-      >
+      <View style={styles.legendContainer}>
         <FontAwesome6 name="location-dot" size={24} color="#d02323" />
-        {width != 40 && <Text style={styles.legendText}>Destination</Text>}
+        {open && <Text style={styles.legendText}>Destination</Text>}
       </View>
-      <View
-        style={{ flexDirection: "row", alignItems: "center", marginBottom: 7 }}
-      >
+      <View style={styles.legendContainer}>
         <View
           style={{
             borderRadius: 13,
@@ -34,11 +28,9 @@ export default function Legend() {
             width: 20,
           }}
         />
-        {width != 40 && <Text style={styles.legendText}>Pick Up Location</Text>}
+        {open && <Text style={styles.legendText}>Pick Up Location</Text>}
       </View>
-      <View
-        style={{ flexDirection: "row", alignItems: "center", marginBottom: 7 }}
-      >
+      <View style={styles.legendContainer}>
         <View
           style={{
             borderRadius: 13,
@@ -58,7 +50,7 @@ export default function Legend() {
             }}
           />
         </View>
-        {width != 40 && <Text style={styles.legendText}>Your Location</Text>}
+        {open && <Text style={styles.legendText}>Your Location</Text>}
       </View>
       <View style={styles.legendContainer}>
         <View
@@ -71,13 +63,13 @@ export default function Legend() {
             width: 20,
           }}
         />
-        {width != 40 && <Text style={styles.legendText}>Start Location</Text>}
+        {open && <Text style={styles.legendText}>Start Location</Text>}
       </View>
-      <Pressable onPress={() => setWidth(width === 40 ? 150 : 40)}>
-        {width == 40 ? (
-          <Feather style={{ width: 40 }} name="chevrons-right" size={20} />
+      <Pressable onPress={() => setOpen(!open)}>
+        {open ? (
+          <Feather name="chevrons-right" size={20} />
         ) : (
-          <Feather style={{ width: 40 }} name="chevrons-left" size={20} />
+          <Feather name="chevrons-left" size={20} />
         )}
       </Pressable>
     </View>


### PR DESCRIPTION
Updates:
- Profile now uses a View instead of an image circle to hold the person user
- Legend width is based on the rendering size needed, not a fixed width

I cannot for the life of me fix the progress bar flex, so I have given up. This isn't a priority so we can do it later if needed.