### PR TITLE
Fix iOS bundle ID

### DIFF
--- a/client/app.config.ts
+++ b/client/app.config.ts
@@ -27,7 +27,7 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
   },
   ios: {
     supportsTablet: true,
-    bundleIdentifier: "com.butterwalkios.butterwalk",
+    bundleIdentifier: "com.butterwalk.butterwalk",
     infoPlist: {
       ITSAppUsesNonExemptEncryption: false,
       NSLocationWhenInUseUsageDescription:

--- a/client/app.json
+++ b/client/app.json
@@ -16,7 +16,7 @@
     },
     "ios": {
       "supportsTablet": true,
-      "bundleIdentifier": "com.butterwalkios.butterwalk",
+      "bundleIdentifier": "com.butterwalk.butterwalk",
       "infoPlist": {
         "ITSAppUsesNonExemptEncryption": false
       }


### PR DESCRIPTION
Quick fix: changed the iOS bundle ID in app.json & app.config.ts to match the Google Cloud Console one ("com.butterwalk.butterwalk")