### PR TITLE
Switched the direction of the Arrow on Legend

### DIFF
--- a/client/components/Student_Legend.tsx
+++ b/client/components/Student_Legend.tsx
@@ -109,9 +109,9 @@ export default function Legend(role: LegendProps) {
       )}
       <Pressable onPress={() => setOpen(!open)}>
         {open ? (
-          <Feather name="chevrons-right" size={20} />
-        ) : (
           <Feather name="chevrons-left" size={20} />
+        ) : (
+          <Feather name="chevrons-right" size={20} />
         )}
       </Pressable>
     </View>


### PR DESCRIPTION
Update:
- changed the Legend arrow so that it points left when the Legend is closed and right when it is open (indicating which direction the legend will go when clicked)