### PR TITLE
Fix Shift Over

### DIFF
--- a/client/app/(driver)/home.tsx
+++ b/client/app/(driver)/home.tsx
@@ -37,7 +37,7 @@ export default function HomePage() {
   /* HOME PAGE STATE */
   const [whichComponent, setWhichComponent] = useState<
     "noRequests" | "requestsAreAvailable" | "handleRide" | "endShift"
-  >("noRequests");
+  >("endShift");
 
   /* USE EFFECTS */
   useEffect(() => {

--- a/client/components/Driver_HandleRide.tsx
+++ b/client/components/Driver_HandleRide.tsx
@@ -162,7 +162,7 @@ export default function HandleRide({
   const cancelRide = () => {
     changeNotifState({
       text: "Ride canceled",
-      color: "#FF0000",
+      color: "#FFCBCB",
     });
     onCancel();
   };

--- a/client/components/Driver_ShiftOver.tsx
+++ b/client/components/Driver_ShiftOver.tsx
@@ -20,7 +20,7 @@ export default function ShiftIsOver({
   useEffect(() => {
     changeNotifState({
       text: "Your shift is over. Log back in when it is your next shift to see new requests.",
-      color: "#FF0000",
+      color: "#FFCBCB",
       boldText: "shift is over",
     });
   }, []);


### PR DESCRIPTION
Here's what was happening:
1. whichComponent starts out as noRequests
2. noRequests calls seeIfRidesExists() on render
3. home page checks if we are in shift time. We are not, so setWhichComponent(endShift) IS CALLED not finished executing
5. Rides exists listener gets a message that rides don't exist and sees that the current whichComponent is noRequests, so it enters the if branch
6. setWhichComponent(endShift) finishes and whichComponent is endShift
7. the rides exist listener continues, and sets whichComponent back to noRequests

Starting at endShift as the default whichComponent prevents the extra seeIfRidesExists() call at the beginning before we have decided if we are in shift or not